### PR TITLE
Update owner references to fix caching behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,18 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Run tests
-      run: docker-compose run --rm tests
-    - name: Run lint
-      run: docker-compose run --rm lint
-    - name: Run shellcheck
-      run: docker-compose run --rm shellcheck
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: docker-compose run --rm tests
+      - name: Run lint
+        run: docker-compose run --rm lint
+      - name: Run shellcheck
+        run: docker-compose run --rm shellcheck

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # S3 Cache Buildkite Plugin
 
-![CI](https://github.com/peakon/s3-cache-buildkite-plugin/workflows/CI/badge.svg?branch=master)
+![CI](https://github.com/commonlit/s3-cache-buildkite-plugin/workflows/CI/badge.svg?branch=master)
 
 Save and restore cache to and from AWS S3.
 
@@ -10,25 +10,24 @@ Add the following to your `pipeline.yml`:
 
 ```yml
 steps:
-  - command: npm install && npm test
-    plugins:
-      - peakon/s3-cache#v2.2.1:
-          id: CACHE_IDENTIFIER # optional, default: none
-          aws_profile: aws-profile-name # optional, default: none
-          restore_dry_run: false # set it to "true" to only check if cacheKey is present on S3 (no download / restoring)
-          save:
-            - key: 'v1-node-modules-{{ checksum("package-lock.json") }}' # required
-              paths: [ "node_modules" ] # required, array of strings
-              when: on_success # optional, one of {always, on_success, on_failure}, default: on_success
-              overwrite: false # optional, set true to overwrite cache on S3 even if object already exists
-          restore:
-            - keys:
-                - 'v1-node-modules-{{ checksum "package-lock.json" }}'
-                - 'v1-node-modules-' # will load latest cache starting with v1-node-modules- (not yet implemented)
+    - command: npm install && npm test
+      plugins:
+          - commonlit/s3-cache#v2.3.0:
+                id: CACHE_IDENTIFIER # optional, default: none
+                aws_profile: aws-profile-name # optional, default: none
+                restore_dry_run: false # set it to "true" to only check if cacheKey is present on S3 (no download / restoring)
+                save:
+                    - key: 'v1-node-modules-{{ checksum("package-lock.json") }}' # required
+                      paths: ["node_modules"] # required, array of strings
+                      when: on_success # optional, one of {always, on_success, on_failure}, default: on_success
+                      overwrite: false # optional, set true to overwrite cache on S3 even if object already exists
+                restore:
+                    - keys:
+                          - 'v1-node-modules-{{ checksum "package-lock.json" }}'
+                          - "v1-node-modules-" # will load latest cache starting with v1-node-modules- (not yet implemented)
 ```
 
 ## Configuration
-
 
 ### Prerequisites
 
@@ -38,46 +37,43 @@ Make sure to set `BUILDKITE_PLUGIN_S3_CACHE_BUCKET_NAME=your-cache-bucket-name` 
 
 You can specify either `save` or `restore` or both of them for a single pipeline step.
 
-
 #### Checking if cache was successfully restored
 
 In some cases you may need to build a conditional logic in the build command based on the results of cache restore operation (for example, to avoid re-generating the cache which already exists and was restored successfully).
 
-To support this use-case, this plugin exports environment variables that can be used during a `command` step. The feature is opt-in and requires `id` to be specified in plugin configuration. 
+To support this use-case, this plugin exports environment variables that can be used during a `command` step. The feature is opt-in and requires `id` to be specified in plugin configuration.
 
 For example, this step generates a cache of `node_modules` (which is then used by all jobs that need it):
 
 ```yml
 steps:
-  - command: "[ ! \"${BUILDKITE_PLUGIN_S3_CACHE_npm_0_KEY_0_HIT}\" =~ ^(true)$ ] && npm install"
-    plugins:
-      - peakon/s3-cache#2.2.1:
-          id: npm
-          restore_dry_run: true # This saves runtime, but doesn't check for integrity 
-          restore:
-            - keys: [ 'v1-node-modules-{{ checksum "package-lock.json" }}' ]
-          save:
-            - key: 'v1-node-modules-{{ checksum "package-lock.json" }}'
-              paths: [ "node_modules" ]
-
+    - command: '[ ! "${BUILDKITE_PLUGIN_S3_CACHE_npm_0_KEY_0_HIT}" =~ ^(true)$ ] && npm install'
+      plugins:
+          - commonlit/s3-cache#2.3.0:
+                id: npm
+                restore_dry_run: true # This saves runtime, but doesn't check for integrity
+                restore:
+                    - keys:
+                          ['v1-node-modules-{{ checksum "package-lock.json" }}']
+                save:
+                    - key: 'v1-node-modules-{{ checksum "package-lock.json" }}'
+                      paths: ["node_modules"]
 ```
-
 
 #### Supported functions
 
-- `checksum 'filename'` - sha256 hash of a `filename`
+-   `checksum 'filename'` - sha256 hash of a `filename`
 
-- `epoch` - time in seconds since Unix epoch (in UTC)
+-   `epoch` - time in seconds since Unix epoch (in UTC)
 
-- `.Environment.SOME_VAR` - a value of environment variable `SOME_VAR`
-
+-   `.Environment.SOME_VAR` - a value of environment variable `SOME_VAR`
 
 #### AWS profiles
 
 You can specify a custom AWS profile to be used by AWS CLI
 
-- in pipeline YAML (`aws_profile: profile_name`)
-- via `BUILDKITE_PLUGIN_S3_CACHE_AWS_PROFILE` environment variable (e.g. inside agent environment hook).
+-   in pipeline YAML (`aws_profile: profile_name`)
+-   via `BUILDKITE_PLUGIN_S3_CACHE_AWS_PROFILE` environment variable (e.g. inside agent environment hook).
 
 ## Developing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   tests:
@@ -7,12 +7,18 @@ services:
       - ".:/plugin:ro"
   lint:
     image: buildkite/plugin-linter:v2.0.3
-    command: ['--id', 'peakon/s3-cache']
+    command: ["--id", "commonlit/s3-cache"]
     volumes:
       - ".:/plugin:ro"
   shellcheck:
     image: koalaman/shellcheck-alpine:latest
     working_dir: "/plugin"
-    command: ["shellcheck", "lib/functions.bash", "hooks/pre-command", "hooks/post-command"]
+    command:
+      [
+        "shellcheck",
+        "lib/functions.bash",
+        "hooks/pre-command",
+        "hooks/post-command",
+      ]
     volumes:
       - ".:/plugin"

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -91,36 +91,36 @@ setup() {
 }
 
 @test "restoreCache with single item" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=v1-cache-key
 
   function s3Restore { echo "true"; }
   export -f s3Restore
-  
+
   run -0 restoreCache
-  
+
   assert_output "Successfully restored v1-cache-key"
 }
 
 @test "restoreCache with multiple caches" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key\"]},{\"keys\":[\"cache-2-key-1\",\"cache-2-key-2\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key\"]},{\"keys\":[\"cache-2-key-1\",\"cache-2-key-2\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=cache-1-key
 
   function s3Restore { echo "true"; }
   export -f s3Restore
-  
+
   run -0 restoreCache
-  
+
   assert_output --partial "Successfully restored cache-1-key"
   assert_output --partial "Successfully restored cache-2-key-1"
   refute_output --partial "cache-2-key-2"
 }
 
 @test "restoreCache with multiple caches and fallback to second cacheKey" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key\"]},{\"keys\":[\"cache-2-key-1\",\"cache-2-key-2\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key\"]},{\"keys\":[\"cache-2-key-1\",\"cache-2-key-2\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=cache-1-key
 
-  function s3Restore { 
+  function s3Restore {
     if [[ "$1" =~ ^cache-2-key-1$ ]]; then
       echo "false"
     else
@@ -128,48 +128,48 @@ setup() {
     fi
   }
   export -f s3Restore
-  
+
   run -0 restoreCache
-  
+
   assert_output --partial "Successfully restored cache-1-key"
   assert_output --partial "Failed to restore cache-2-key-1"
   assert_output --partial "Successfully restored cache-2-key-2"
 }
 
 @test "restoreCache for first plugin configuration in case of multiple plugins" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key\"]},{\"keys\":[\"cache-2-key-1\",\"cache-2-key-2\"]}]}},{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-3-key\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key\"]},{\"keys\":[\"cache-2-key-1\",\"cache-2-key-2\"]}]}},{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-3-key\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=cache-1-key
 
-  function s3Restore { 
+  function s3Restore {
     echo "true"
   }
   export -f s3Restore
-  
+
   run -0 restoreCache
-  
+
   assert_output --partial "Successfully restored cache-1-key"
   assert_output --partial "Successfully restored cache-2-key-1"
   refute_output --partial "Successfully restored cache-3-key"
 }
 
 @test "restoreCache for second plugin configuration in case of multiple plugins" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key\"]},{\"keys\":[\"cache-2-key-1\",\"cache-2-key-2\"]}]}},{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-3-key\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key\"]},{\"keys\":[\"cache-2-key-1\",\"cache-2-key-2\"]}]}},{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-3-key\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=cache-3-key
 
-  function s3Restore { 
+  function s3Restore {
     echo "true"
   }
   export -f s3Restore
-  
+
   run -0 restoreCache
-  
+
   refute_output --partial "Successfully restored cache-1-key"
   refute_output --partial "Successfully restored cache-2-key-1"
   assert_output --partial "Successfully restored cache-3-key"
 }
 
 @test "restoreCache with named cache should export CACHE_HIT=true" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=v1-cache-key
   export BUILDKITE_PLUGIN_S3_CACHE_ID="FOO_BAR"
 
@@ -181,14 +181,14 @@ setup() {
   }
   export -f s3Restore
   export -f exportEnvVar
-  
+
   restoreCache
 
   assert_equal "${exportedEnvironment[*]}" "BUILDKITE_PLUGIN_S3_CACHE_FOO_BAR_0_KEY_0_HIT=true"
 }
 
 @test "restoreCache with named cache should export CACHE_HIT=false" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=v1-cache-key
   export BUILDKITE_PLUGIN_S3_CACHE_ID="FOO_BAR"
 
@@ -200,14 +200,14 @@ setup() {
   }
   export -f s3Restore
   export -f exportEnvVar
-  
+
   restoreCache
 
   assert_equal "${exportedEnvironment[*]}" "BUILDKITE_PLUGIN_S3_CACHE_FOO_BAR_0_KEY_0_HIT=false"
 }
 
 @test "restoreCache with named cache should correctly export CACHE_HIT in case of cache miss on the first key" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key-1\", \"cache-1-key-2\"]},{\"keys\":[\"cache-2-key-1\"]} ]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-1-key-1\", \"cache-1-key-2\"]},{\"keys\":[\"cache-2-key-1\"]} ]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=cache-1-key-1
   export BUILDKITE_PLUGIN_S3_CACHE_ID="FOO_BAR"
 
@@ -225,7 +225,7 @@ setup() {
   }
   export -f s3Restore
   export -f exportEnvVar
-  
+
   restoreCache
 
   declare -a expected
@@ -237,20 +237,20 @@ setup() {
 }
 
 @test "restoreCache with restore_dry_run=true should only check if cache exists on S3" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=v1-cache-key
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_DRY_RUN="true"
 
   function s3Exists { echo "true"; }
   export -f s3Exists
-  
+
   run -0 restoreCache
 
   assert_output --partial "Successfully restored v1-cache-key"
 }
 
 @test "restoreCache with id:FOO_BAR and restore_dry_run=true should export BUILDKITE_PLUGIN_S3_CACHE_FOO_BAR_0_KEY_0_HIT=false if cache is missing" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=v1-cache-key
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_DRY_RUN="true"
   export BUILDKITE_PLUGIN_S3_CACHE_ID="FOO_BAR"
@@ -263,7 +263,7 @@ setup() {
   }
   export -f s3Exists
   export -f exportEnvVar
-  
+
   restoreCache
 
   assert_equal "${exportedEnvironment[*]}" "BUILDKITE_PLUGIN_S3_CACHE_FOO_BAR_0_KEY_0_HIT=false"
@@ -271,7 +271,7 @@ setup() {
 
 
 @test "saveCache with single cacheItem" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"save\":[{\"key\":\"v1-node-modules\",\"paths\":[\"node_modules\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"save\":[{\"key\":\"v1-node-modules\",\"paths\":[\"node_modules\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_SAVE_0_KEY=v1-node-modules
   function s3Exists {
     echo "false"
@@ -282,14 +282,14 @@ setup() {
     echo "true"
   }
   export -f s3Upload
-  
+
   run -0 saveCache
-  
+
   assert_output --partial "Uploaded new cache for key: v1-node-modules"
 }
 
 # @test "saveCache with overwrite cacheItem" {
-#   export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"save\":[{\"key\":\"v1-node-modules\",\"paths\":[\"node_modules\"]},{\"key\":\"v1-eslint-cache\",\"paths\":[\"node_modules/.eslintcache\"],\"overwrite\":true}]}}]"
+#   export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"save\":[{\"key\":\"v1-node-modules\",\"paths\":[\"node_modules\"]},{\"key\":\"v1-eslint-cache\",\"paths\":[\"node_modules/.eslintcache\"],\"overwrite\":true}]}}]"
 
 #   function s3Exists {
 #     echo "false"
@@ -300,9 +300,9 @@ setup() {
 #     echo "true"
 #   }
 #   export -f s3Upload
-  
+
 #   output=$(saveCache)
-  
+
 #   assert_success
 #   assert_output --partial "Successfully saved v1-node-modules"
 # }

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -25,8 +25,8 @@ function teardown() {
     unstub tar
 }
 
-@test "Pre-command succeeds to restore singe cache item" { 
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
+@test "Pre-command succeeds to restore singe cache item" {
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"v1-cache-key\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=v1-cache-key
 
   stub aws \
@@ -40,7 +40,7 @@ function teardown() {
 }
 
 @test "Pre-command succeeds to restore from a fallback key if first key is missing" {
-  export BUILDKITE_PLUGINS="[{\"github.com/peakon/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-key-missing\",\"cache-key-exists\"]}]}}]"
+  export BUILDKITE_PLUGINS="[{\"github.com/commonlit/s3-cache-buildkite-plugin#v1.5.0\":{\"restore\":[{\"keys\":[\"cache-key-missing\",\"cache-key-exists\"]}]}}]"
   export BUILDKITE_PLUGIN_S3_CACHE_RESTORE_0_KEYS_0=cache-key-missing
 
   stub aws \


### PR DESCRIPTION
This plugin had some hard-coded references to the author that caused caching to not work when we forked it for supply-chain security. This change updates the owner to be `commonlit` so that we can use the fork in our pipelines.